### PR TITLE
CCNode: Fix loop in Visit() to not break on invisible children.

### DIFF
--- a/src/base_nodes/CCNode.cs
+++ b/src/base_nodes/CCNode.cs
@@ -2043,9 +2043,13 @@ namespace CocosSharp
                 // draw children zOrder < 0
                 for (; i < count; ++i)
                 {
-                    if (elements[i].Visible && elements[i].zOrder < 0)
+                    if (elements[i].zOrder < 0)
                     {
-                        elements[i].Visit();
+                        // don't break loop on invisible children
+                        if (elements[i].Visible)
+                        {
+                            elements[i].Visit();
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
An invisible child would cause other children with local z-order less than 0 to be drawn on top of the parent.

To reproduce:
Create a CCSprite, attach two children. First child, z-order of -2 and invisible. Second child, z-order of -1. Second child would be drawn on top of parent sprite. If you "blink" the first child, the second child will jump behind, then in front of, the parent sprite.

The original cocos2d-X (and very old cocos2d-xna) source does not check for visibility in this loop. When the visibility check was added, it was done incorrectly (IMHO). Granted this is a rare case, but it is still a bug.
