### PR TITLE
Set property DeviceManager

### DIFF
--- a/src/CCWindow.cs
+++ b/src/CCWindow.cs
@@ -140,7 +140,8 @@ namespace CocosSharp
             this.XnaWindow = xnaWindow;
             xnaWindow.OrientationChanged += OnOrientationChanged;
             xnaWindow.ClientSizeChanged += OnWindowSizeChanged;
-
+            
+            DeviceManager = deviceManager;
             // Trying to set user resize when game is full-screen will cause app to crash 
             if(!deviceManager.IsFullScreen)
                 xnaWindow.AllowUserResizing = true;


### PR DESCRIPTION
The property DeviceManager was always null. For example if you wanted to set Fullscreen to false, you got a NullReferenceException.