### PR TITLE
Set SharedDrawManager to null when disposing

### DIFF
--- a/src/platform/CCApplication.cs
+++ b/src/platform/CCApplication.cs
@@ -639,6 +639,15 @@ namespace CocosSharp
         {
             CCLabelBMFont.PurgeCachedData();
         }
+        
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                CCDrawManager.SharedDrawManager = null;
+            }
+            base.Dispose(disposing);
+        }
 
         #endregion Cleaning up
 


### PR DESCRIPTION
My game on Android crashed when I went to another Activity and came back, because of a check if the GraphicsDevice is null:

See InitializeMainWindow(CCSize windowSizeInPixels, bool isFullscreen = false) on line 557.