### PR TITLE
Polyline tilemap test: Changed code for drawing rectangles, polygons, an...

### DIFF
--- a/tests/tests/classes/tests/TileMapTest/Shapes.cs
+++ b/tests/tests/classes/tests/TileMapTest/Shapes.cs
@@ -1,26 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using CocosSharp;
 
 namespace tests
 {
-	public class TmxMapRectangle : CCNode
-	{
-		public CCRect Rect { get; set; }
-
-		protected override void Draw()
-		{
-			base.Draw();
-
-			var color = new CCColor4B( Color.R, Color.G, Color.B );
-
-			CCDrawingPrimitives.Begin();
-			CCDrawingPrimitives.LineWidth = 2.0f;
-			CCDrawingPrimitives.DrawRect(Rect, color);
-			CCDrawingPrimitives.End();
-		}
-	}
-
 	public class TmxMapEllipse : CCNode
 	{
 		public CCRect Rect { get; set; }
@@ -37,42 +19,4 @@ namespace tests
 			CCDrawingPrimitives.End();
 		}
 	}
-
-	public class TmxMapPolygon : CCNode
-	{
-		public List<CCPoint> Points { get; set; }
-
-		protected override void Draw()
-		{
-			base.Draw();
-
-			var color = new CCColor4B( Color.R, Color.G, Color.B );
-
-			CCDrawingPrimitives.Begin();
-			CCDrawingPrimitives.LineWidth = 2.0f;
-			CCDrawingPrimitives.DrawPoly(Points.ToArray(), color, true);
-			CCDrawingPrimitives.End();
-		}
-	}
-
-	public class TmxMapPolyline : CCNode
-	{
-		public List<CCPoint> Points { get; set; }
-
-		protected override void Draw()
-		{
-			base.Draw();
-
-			var color = new CCColor4B( Color.R, Color.G, Color.B );
-
-			CCDrawingPrimitives.Begin();
-			CCDrawingPrimitives.LineWidth = 2.0f;
-			for ( int i = 0; i < Points.Count-1; i++ )
-			{
-				CCDrawingPrimitives.DrawLine(Points[i], Points[i+1], color);
-			}
-			CCDrawingPrimitives.End();
-		}
-	}
-
 }


### PR DESCRIPTION
I've converted this to use CCDrawNode for everything but drawing ellipses. I just don't see an easy way to do that in CCDrawNode. Do you have an example of this that I can look at? It would be nice to do away with the TmxMapEllipse class in favor of a more generic draw method.