### PR TITLE
SearchResolutionOrder and SearchPaths contain at least empty string

### DIFF
--- a/src/label_nodes/CCFontSpriteFont.cs
+++ b/src/label_nodes/CCFontSpriteFont.cs
@@ -38,32 +38,24 @@ namespace CocosSharp
 
         internal override CCFontAtlas CreateFontAtlas()
         {
-            var atlas = new CCFontAtlas(this);
-
-            // Try to load the texture
-            CCTexture2D atlasTexture = null;
-
             float loadedSize = fontSize;
-
             SpriteFont font = CCSpriteFontCache.SharedInstance.TryLoadFont(fontName, fontSize, out loadedSize);
             if (font == null)
             {
-                atlasTexture = new CCTexture2D(); 
+                return null;
             }
-            else
-            {
 #if XNA
-                atlasTexture = new CCTexture2D();
+            CCTexture2D atlasTexture = new CCTexture2D();
 #else
-                atlasTexture = new CCTexture2D(font.Texture);
+            CCTexture2D atlasTexture = new CCTexture2D(font.Texture);
 #endif
-            }
 
             if (loadedSize != 0)
             {
                 fontScale = fontSize / loadedSize * CCSpriteFontCache.FontScale;
             }
 
+            var atlas = new CCFontAtlas(this);
             // add the texture (only one for now)
             atlas.AddTexture(atlasTexture, 0);
 

--- a/src/platform/CCContentManager.cs
+++ b/src/platform/CCContentManager.cs
@@ -175,12 +175,9 @@ namespace CocosSharp
 
             var realName = GetRealName(assetName);
 
-            CheckDefaultPath(searchPaths);
-            CheckDefaultPath(searchResolutionsOrder);
-
-            foreach (var searchPath in searchPaths)
+            foreach (var searchPath in SearchPaths)
             {
-                foreach (string resolutionOrder in searchResolutionsOrder)
+                foreach (string resolutionOrder in SearchResolutionsOrder)
                 {
                     var path = Path.Combine(Path.Combine(searchPath, resolutionOrder), realName);
 
@@ -354,12 +351,9 @@ namespace CocosSharp
             fileName = string.Empty;
             var realName = GetRealName(assetName);
 
-            CheckDefaultPath(searchPaths);
-            CheckDefaultPath(searchResolutionsOrder);
-
-            foreach (var searchPath in searchPaths)
+            foreach (var searchPath in SearchPaths)
             {
-                foreach (string resolutionOrder in searchResolutionsOrder)
+                foreach (string resolutionOrder in SearchResolutionsOrder)
                 {
                     var path = Path.Combine(Path.Combine(RootDirectory, Path.Combine(searchPath, resolutionOrder)), realName);
 
@@ -416,16 +410,24 @@ namespace CocosSharp
 
         public List<string> SearchResolutionsOrder
         {
-            get { return searchResolutionsOrder; }
+            get
+            {
+                CheckDefaultPath(searchResolutionsOrder);
+                return searchResolutionsOrder;
+            }
 
-			internal set { searchResolutionsOrder = value; }
+            internal set { searchResolutionsOrder = value; }
         }
 
         public List<string> SearchPaths
         {
-            get { return searchPaths; }
+            get
+            {
+                CheckDefaultPath(searchPaths);
+                return searchPaths;
+            }
 
-			internal set { searchPaths = value; }
+            internal set { searchPaths = value; }
         }
 
         void CheckDefaultPath(List<string> paths)


### PR DESCRIPTION
It prevents bugs one of those described at issue #183 