### PR TITLE
Fix: Wrong rendering of hex tileset (handles #197)

### DIFF
--- a/src/tileMap_parallax_nodes/CCTileMapLayer.cs
+++ b/src/tileMap_parallax_nodes/CCTileMapLayer.cs
@@ -297,10 +297,10 @@ namespace CocosSharp
 
                     tileCoordsToNodeTransformOdd = new CCAffineTransform(new Matrix
                         (
-                            height * (float)Math.Sqrt(0.75), -height/2, 0.0f, 0.0f,
+                            height * (float)Math.Sqrt(0.75), 0.0f, 0.0f, 0.0f,
                             0.0f , -height, 0.0f, 0.0f,
                             0.0f, 0.0f, 1.0f, 0.0f,
-                            0.0f, yOffset, 0.0f, 1.0f
+                            0.0f, yOffset - height/2, 0.0f, 1.0f
                         ));
                     break;
                 case CCTileMapType.Staggered:


### PR DESCRIPTION
This PR fixes a rendering problem of hex tilesets by correcting the transformation matrix for odd column indexes. See issue #197 for details and a screenshot.