### PR TITLE
CCStats texture format changed to work on WP81

### DIFF
--- a/src/CCStats.cs
+++ b/src/CCStats.cs
@@ -145,7 +145,11 @@ namespace CocosSharp
 				stopwatch = new Stopwatch ();
 
 				try {
-					texture = !textureCache.Contains ("cc_fps_images") ? textureCache.AddImage (CCFPSImage.PngData, "cc_fps_images", CCSurfaceFormat.Bgra4444) : textureCache ["cc_fps_images"];
+                    var surfaceFormat = CCSurfaceFormat.Bgra4444;
+#if WINDOWS_PHONE81
+                    surfaceFormat = CCSurfaceFormat.Color;
+#endif
+					texture = !textureCache.Contains ("cc_fps_images") ? textureCache.AddImage (CCFPSImage.PngData, "cc_fps_images", surfaceFormat) : textureCache ["cc_fps_images"];
 
 					// Analysis disable CompareOfFloatsByEqualityOperator
 					if (texture == null || (texture.ContentSizeInPixels.Width == 0 && texture.ContentSizeInPixels.Height == 0)) {


### PR DESCRIPTION
This pull requests brings working CCStats to the WP8.1 devices (before it was working only on WP8.1 emulator).

I assume there might be a better or more correct way to solve, so I'm open for suggestions.