### PR TITLE
Fixed typographical error, changed aggresive to aggressive in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ So to get started we have placed a number of samples here: [Samples](https://git
 
 ### Statistics
 
-There is a special case for Xamarin iOS MonoTouch running on the simulator where they aggresively call garbage collection themselves.  This should not affect the devices though.  On the Simulator the GC label will always be 0 (zero)
+There is a special case for Xamarin iOS MonoTouch running on the simulator where they aggressively call garbage collection themselves.  This should not affect the devices though.  On the Simulator the GC label will always be 0 (zero)
 
 
 History


### PR DESCRIPTION
@mono, I've corrected a typographical error in the documentation of the [CocosSharp](https://github.com/mono/CocosSharp) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.