### PR TITLE
[wp81] fix for CCUserDefaults.Flush corrupting files

### DIFF
--- a/src/support/CCUserDefault.cs
+++ b/src/support/CCUserDefault.cs
@@ -329,7 +329,7 @@ namespace CocosSharp
     		bool bRet = false;
 
     #if NETFX_CORE
-            using (StreamWriter writeFile = new StreamWriter(myIsolatedStorage.OpenFile(XML_FILE_NAME, FileMode.OpenOrCreate)))
+            using (StreamWriter writeFile = new StreamWriter(myIsolatedStorage.OpenFile(XML_FILE_NAME, FileMode.Create)))
     #elif WINDOWS || LINUX || MACOS || WINDOWSGL
     		using (StreamWriter writeFile = new StreamWriter(XML_FILE_NAME)) 
     #else
@@ -347,7 +347,7 @@ namespace CocosSharp
     	public void Flush()
     	{
     #if NETFX_CORE
-            using (Stream stream = myIsolatedStorage.OpenFile(XML_FILE_NAME, FileMode.OpenOrCreate))
+            using (Stream stream = myIsolatedStorage.OpenFile(XML_FILE_NAME, FileMode.Create))
     #elif WINDOWS || LINUX || MACOS || WINDOWSGL
     		using (StreamWriter stream = new StreamWriter(XML_FILE_NAME)) 
     #else


### PR DESCRIPTION
This pull requests fixes problem on WP8.1
After multiple calls to CCUserDefaults.Flush file is corrupted.

I experienced this in my game.
Additional information (it's known issue for WP developers): http://stackoverflow.com/questions/29799265/filemode-open-and-filemode-openorcreate-difference-when-file-exists-c-sharp-bug

Would be great after (and if) this pull request is merged, get a fresh Nuget version.
Thank you.