### PR TITLE
Update template for XS6

### DIFF
--- a/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.Forms/Empty.Forms/MonoDevelop.CocosSharp.Forms.EmptyProject.xpt.xml
+++ b/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.Forms/Empty.Forms/MonoDevelop.CocosSharp.Forms.EmptyProject.xpt.xml
@@ -26,7 +26,7 @@
             </Files>
         </Project>
 
-        <Project name = "${ProjectName}" directory = "." type = "PortableDotNet" if = "CreatePortableDotNetProject" >
+        <Project name = "${ProjectName}" directory = "." type = "C#PortableLibrary" if = "CreatePortableDotNetProject" >
             <Options Target = "Library" TargetFrameworkVersion = ".NETPortable,Version=v4.5,Profile=Profile111"/>
             <Files>
                 <File name="${ProjectName}.cs" AddStandardHeader="True" src="../Common.Forms/App.cs" />

--- a/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.Forms/Showcase.Forms/MonoDevelop.CocosSharp.Forms.ShowcaseProject.xpt.xml
+++ b/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.Forms/Showcase.Forms/MonoDevelop.CocosSharp.Forms.ShowcaseProject.xpt.xml
@@ -26,7 +26,7 @@
             </Files>
         </Project>
 
-        <Project name = "${ProjectName}" directory = "." type = "PortableDotNet" if = "CreatePortableDotNetProject" >
+        <Project name = "${ProjectName}" directory = "." type = "C#PortableLibrary" if = "CreatePortableDotNetProject" >
             <Options Target = "Library" TargetFrameworkVersion = ".NETPortable,Version=v4.5,Profile=Profile111"/>
             <Files>
                 <File name="${ProjectName}.cs" AddStandardHeader="True" src="../Common.Forms/App.cs" />

--- a/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.Mobile/Empty.Mobile/MonoDevelop.CocosSharp.Mobile.EmptyProject.xpt.xml
+++ b/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.Mobile/Empty.Mobile/MonoDevelop.CocosSharp.Mobile.EmptyProject.xpt.xml
@@ -124,7 +124,7 @@
 
 
         <!---PCL project -->
-        <Project name = "${ProjectName}.Common" directory = "${ProjectName}/${ProjectName}.Common" type = "PortableDotNet">
+        <Project name = "${ProjectName}.Common" directory = "${ProjectName}/${ProjectName}.Common" type = "C#PortableLibrary">
             <Options Target = "Library" TargetFrameworkVersion = ".NETPortable,Version=v4.5,Profile=Profile111" />
             <Files>
                 <File name="GameLayer.cs" AddStandardHeader="True" src="../../Common/EmptyLayer.cs" />

--- a/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.Mobile/SingleWindowed.Mobile/MonoDevelop.CocosSharp.Mobile.MobileProject.xpt.xml
+++ b/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.Mobile/SingleWindowed.Mobile/MonoDevelop.CocosSharp.Mobile.MobileProject.xpt.xml
@@ -123,7 +123,7 @@
         </Project>
 
         <!---PCL project -->
-        <Project name = "${ProjectName}.Common" directory = "${ProjectName}/${ProjectName}.Common" type = "PortableDotNet">
+        <Project name = "${ProjectName}.Common" directory = "${ProjectName}/${ProjectName}.Common" type = "C#PortableLibrary">
             <Options Target = "Library" TargetFrameworkVersion = ".NETPortable,Version=v4.5,Profile=Profile111"/>
             <Files>
                 <File name="GameLayer.cs" AddStandardHeader="True" src="../../Common/GameLayer.cs" />

--- a/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.addin.xml
+++ b/ProjectTemplates/XamarinStudio/MonoDevelop.CocosSharp.addin.xml
@@ -107,8 +107,8 @@
 
     <!--- Common dependencies -->
     <Dependencies>
-        <Addin id="Core"        version="5.0"/>
-        <Addin id="Ide"         version="5.0"/>
+        <Addin id="Core"        version="6.0"/>
+        <Addin id="Ide"         version="6.0"/>
     </Dependencies>
 
 
@@ -142,7 +142,7 @@
     <!-- Android project templates -->
     <Module>
         <Dependencies>
-            <Addin id="MonoAndroid" version="5.0"/>
+            <Addin id="MonoAndroid" version="6.0"/>
         </Dependencies>
         <Extension path="/MonoDevelop/Ide/ProjectTemplates">
             <ProjectTemplate
@@ -157,7 +157,7 @@
     <!-- iOS project templates -->
     <Module>
         <Dependencies>
-            <Addin id="IPhone" version="5.0"/>
+            <Addin id="IPhone" version="6.0"/>
         </Dependencies>
         <Extension path="/MonoDevelop/Ide/ProjectTemplates">
             <ProjectTemplate
@@ -172,7 +172,7 @@
     <!-- Mobile project templates -->
     <Module>
         <Dependencies>
-            <Addin id="MonoAndroid" version="5.0"/>
+            <Addin id="MonoAndroid" version="6.0"/>
         </Dependencies>
         <Extension path="/MonoDevelop/Ide/ProjectTemplates">
             <ProjectTemplate
@@ -188,8 +188,8 @@
     <!-- Xamarin.Forms project templates -->
     <Module>
         <Dependencies>
-            <Addin id="MonoAndroid" version="5.0"/>
-            <Addin id="IPhone" version="5.0"/>
+            <Addin id="MonoAndroid" version="6.0"/>
+            <Addin id="IPhone" version="6.0"/>
         </Dependencies>
         <Extension path="/MonoDevelop/Ide/ProjectTemplates">
             <ProjectTemplate


### PR DESCRIPTION
After XS6 update, MonoDevelop.CocosSharp.Templates add-in is broken. I updated for this change.

I couldn't find this changes from the release note but I found some information below:
- https://github.com/PrismLibrary/Prism/issues/638#issuecomment-227186035
- https://www.jimbobbennett.io/more-on-xamarin-studio-add-ins/

Releated https://github.com/mono/CocosSharp/issues/362
